### PR TITLE
fix(sync): switch to gh issue list for reliable auth and pagination

### DIFF
--- a/.github/workflows/sync-issues-to-src.yml
+++ b/.github/workflows/sync-issues-to-src.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
-
       - name: Export all issues to src/blogs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-issues-to-src.yml
+++ b/.github/workflows/sync-issues-to-src.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   issues: read
 
+concurrency:
+  group: sync-issues-to-src
+  cancel-in-progress: true
+
 jobs:
   sync-issues:
     runs-on: ubuntu-latest

--- a/export_issues.py
+++ b/export_issues.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Sync GitHub issues into mdBook markdown files.
 
-- Reads all issues from a repo (paginated)
-- Skips pull requests
+- Reads all issues from a repo via `gh issue list` (excludes PRs automatically)
 - Skips issues labeled TODO (configurable)
 - Writes files to src/blogs/qiwihui-blog-<issue_number>.md
 - Rebuilds src/SUMMARY.md sorted by issue number (desc)
@@ -11,59 +10,41 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, Iterable, List
-
-import requests
 
 DEFAULT_REPO = "qiwihui/blog"
 DEFAULT_OUTPUT_DIR = Path("src/blogs")
 DEFAULT_SUMMARY_FILE = Path("src/SUMMARY.md")
 
 
-def github_headers(token: str | None) -> Dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
 def fetch_all_issues(repo: str, token: str | None) -> List[Dict]:
-    """Fetch all issues from GitHub (includes PRs from /issues endpoint)."""
-    all_issues: List[Dict] = []
-    page = 1
-    per_page = 100
+    """Fetch all issues (not PRs) via gh CLI, which handles auth and pagination."""
+    env = os.environ.copy()
+    if token:
+        env["GH_TOKEN"] = token
 
-    while True:
-        url = f"https://api.github.com/repos/{repo}/issues"
-        resp = requests.get(
-            url,
-            params={
-                "state": "all",
-                "per_page": per_page,
-                "page": page,
-                "sort": "created",
-                "direction": "asc",
-            },
-            headers=github_headers(token),
-            timeout=30,
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", "all",
+        "--json", "number,title,body,labels,state,url",
+        "--limit", "10000",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue list failed (exit {result.returncode}):\n{result.stderr.strip()}"
         )
-        resp.raise_for_status()
-        chunk = resp.json()
-        if not chunk:
-            break
 
-        all_issues.extend(chunk)
-        if len(chunk) < per_page:
-            break
-        page += 1
-
-    return all_issues
+    issues = json.loads(result.stdout)
+    print(f"Fetched {len(issues)} issues from {repo}")
+    return issues
 
 
 def labels_of(issue: Dict) -> List[str]:
@@ -74,7 +55,7 @@ def issue_markdown(issue: Dict) -> str:
     title = issue.get("title", "")
     body = issue.get("body") or ""
     number = issue.get("number")
-    issue_url = issue.get("html_url", "")
+    issue_url = issue.get("url") or issue.get("html_url", "")
     state = issue.get("state", "unknown")
 
     return (
@@ -94,7 +75,7 @@ def write_issue_files(issues: Iterable[Dict], output_dir: Path) -> None:
         file_path.write_text(issue_markdown(issue), encoding="utf-8")
 
 
-def write_summary(issues: Iterable[Dict], summary_file: Path, output_dir: Path) -> None:
+def write_summary(issues: Iterable[Dict], summary_file: Path) -> None:
     sorted_issues = sorted(issues, key=lambda x: x["number"], reverse=True)
 
     lines = ["# Summary", "", "[About Me](./README.md)"]
@@ -108,27 +89,38 @@ def write_summary(issues: Iterable[Dict], summary_file: Path, output_dir: Path) 
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Export all GitHub issues to mdBook src markdown files")
-    parser.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY", DEFAULT_REPO), help="owner/repo")
-    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN", ""), help="GitHub token")
+    parser = argparse.ArgumentParser(
+        description="Export all GitHub issues to mdBook src markdown files"
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.getenv("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help="owner/repo",
+    )
+    parser.add_argument(
+        "--token", default=os.getenv("GITHUB_TOKEN", ""), help="GitHub token"
+    )
     parser.add_argument("--skip-label", default="TODO", help="Label name to skip")
-    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Output directory for markdown files")
-    parser.add_argument("--summary-file", default=str(DEFAULT_SUMMARY_FILE), help="Path of SUMMARY.md")
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Output directory for markdown files",
+    )
+    parser.add_argument(
+        "--summary-file",
+        default=str(DEFAULT_SUMMARY_FILE),
+        help="Path of SUMMARY.md",
+    )
     args = parser.parse_args()
 
     issues = fetch_all_issues(args.repo, args.token or None)
 
-    filtered = [
-        i
-        for i in issues
-        if "pull_request" not in i and args.skip_label not in labels_of(i)
-    ]
+    filtered = [i for i in issues if args.skip_label not in labels_of(i)]
 
     if not filtered:
         print(
-            f"ERROR: fetched {len(issues)} items from API but 0 passed the filter "
-            f"(skip_label={args.skip_label!r}). Refusing to overwrite {args.summary_file} "
-            "with empty content — check token permissions and repo name.",
+            f"ERROR: fetched {len(issues)} issues but 0 passed the filter "
+            f"(skip_label={args.skip_label!r}). Refusing to overwrite {args.summary_file}.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -137,7 +129,7 @@ def main() -> None:
     summary_file = Path(args.summary_file)
 
     write_issue_files(filtered, output_dir)
-    write_summary(filtered, summary_file, output_dir)
+    write_summary(filtered, summary_file)
 
     print(f"Synced {len(filtered)} issues into {output_dir} and {summary_file}")
 


### PR DESCRIPTION
## 问题

PR #191 合并后仍然不起作用。通过本地测试发现了真正的根本原因：

**`requests` 分页在 GitHub Actions 中不可靠**

两种失败场景：
1. **token 有 `issues: none`**：GitHub 对 page 1 返回 `[]`（认证成功但无权限），脚本提前退出得到空列表 → SUMMARY.md 被清空
2. **无 token（本地）**：page 1 成功（公开访问），page 2 返回 403 → 脚本异常退出

## 修复方案

**改用 `gh issue list`**（GitHub Actions ubuntu-latest 预装）：

```python
result = subprocess.run([
    "gh", "issue", "list",
    "--repo", repo,
    "--state", "all",
    "--json", "number,title,body,labels,state,url",
    "--limit", "10000",
], ...)
```

优势：
- `gh` 自动读取 `GITHUB_TOKEN`，认证从不失败
- 内置分页，不需要手写循环
- 只返回 issues，不含 PR，可去掉 `pull_request` 过滤逻辑
- 失败时报清晰错误，不会静默返回空列表

## 变更内容

- `export_issues.py`：用 `gh issue list` 替换 `requests` 分页逻辑，移除 `requests` 依赖
- `.github/workflows/sync-issues-to-src.yml`：
  - 移除 `pip install requests`（不再需要）
  - 补充 `concurrency` 并发控制（PR #191 合并时漏掉了这一提交）

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPCPwUYcaZnCfrPU7PNKHm)_