### PR TITLE
fix(sync): reliable issue sync with gh CLI, concurrency guard, and atom.xml generation

### DIFF
--- a/.github/workflows/sync-issues-to-src.yml
+++ b/.github/workflows/sync-issues-to-src.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
-
       - name: Export all issues to src/blogs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-issues-to-src.yml
+++ b/.github/workflows/sync-issues-to-src.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install dependencies
+        run: pip install markdown
+
       - name: Export all issues to src/blogs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-issues-to-src.yml
+++ b/.github/workflows/sync-issues-to-src.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   issues: read
 
+concurrency:
+  group: sync-issues-to-src
+  cancel-in-progress: true
+
 jobs:
   sync-issues:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ DS_Store
 
 # Rust
 */*/target/
+
+# Python
+__pycache__/

--- a/export_issues.py
+++ b/export_issues.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Sync GitHub issues into mdBook markdown files.
+"""Sync GitHub issues into mdBook markdown files and Atom feed.
 
 - Reads all issues from a repo via `gh issue list` (excludes PRs automatically)
 - Skips issues labeled TODO (configurable)
 - Writes files to src/blogs/qiwihui-blog-<issue_number>.md
 - Rebuilds src/SUMMARY.md sorted by issue number (desc)
+- Rebuilds src/atom.xml (20 most recently updated issues)
 """
 
 from __future__ import annotations
@@ -14,12 +15,19 @@ import json
 import os
 import subprocess
 import sys
+import xml.sax.saxutils as saxutils
 from pathlib import Path
 from typing import Dict, Iterable, List
+
+import markdown as md_lib
 
 DEFAULT_REPO = "qiwihui/blog"
 DEFAULT_OUTPUT_DIR = Path("src/blogs")
 DEFAULT_SUMMARY_FILE = Path("src/SUMMARY.md")
+DEFAULT_ATOM_FILE = Path("src/atom.xml")
+BASE_URL = "https://qiwihui.com"
+ATOM_AUTHOR = {"name": "qiwihui", "email": "qwh005007@gmail.com"}
+ATOM_FEED_SIZE = 20
 
 
 def fetch_all_issues(repo: str, token: str | None) -> List[Dict]:
@@ -32,7 +40,7 @@ def fetch_all_issues(repo: str, token: str | None) -> List[Dict]:
         "gh", "issue", "list",
         "--repo", repo,
         "--state", "all",
-        "--json", "number,title,body,labels,state,url",
+        "--json", "number,title,body,labels,state,url,createdAt,updatedAt",
         "--limit", "10000",
     ]
 
@@ -88,6 +96,61 @@ def write_summary(issues: Iterable[Dict], summary_file: Path) -> None:
     summary_file.write_text("\n".join(lines), encoding="utf-8")
 
 
+def _xml(tag: str, text: str, **attrs: str) -> str:
+    attr_str = "".join(f' {k}="{v}"' for k, v in attrs.items())
+    return f"<{tag}{attr_str}>{saxutils.escape(text)}</{tag}>"
+
+
+def write_atom(issues: List[Dict], atom_file: Path) -> None:
+    """Generate Atom feed from the most recently updated issues."""
+    feed_issues = sorted(
+        issues,
+        key=lambda x: x.get("updatedAt") or x.get("createdAt") or "",
+        reverse=True,
+    )[:ATOM_FEED_SIZE]
+
+    feed_updated = feed_issues[0].get("updatedAt", "") if feed_issues else ""
+
+    parts = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<feed xmlns="http://www.w3.org/2005/Atom">',
+        _xml("title", "Qiwihui's blog"),
+        _xml("id", f"{BASE_URL}/atom.xml"),
+        _xml("updated", feed_updated),
+        f'<link href="{BASE_URL}/" rel="alternate"/>',
+        f'<link href="{BASE_URL}/atom.xml" rel="self"/>',
+        f'<author>{_xml("name", ATOM_AUTHOR["name"])}'
+        f'{_xml("email", ATOM_AUTHOR["email"])}</author>',
+    ]
+
+    for issue in feed_issues:
+        number = issue["number"]
+        title = issue.get("title", "")
+        body = issue.get("body") or ""
+        issue_url = issue.get("url", f"{BASE_URL}/blogs/qiwihui-blog-{number}.html")
+        blog_url = f"{BASE_URL}/blogs/qiwihui-blog-{number}.html"
+        created_at = issue.get("createdAt", "")
+        updated_at = issue.get("updatedAt") or created_at
+
+        html_body = md_lib.markdown(body, extensions=["fenced_code", "tables"])
+
+        parts += [
+            "<entry>",
+            _xml("title", f"{number}. {title}"),
+            _xml("id", issue_url),
+            _xml("updated", updated_at),
+            _xml("published", created_at),
+            f'<author>{_xml("name", ATOM_AUTHOR["name"])}'
+            f'{_xml("email", ATOM_AUTHOR["email"])}</author>',
+            f'<link href="{blog_url}" rel="alternate"/>',
+            f"<content type=\"html\">{saxutils.escape(html_body)}</content>",
+            "</entry>",
+        ]
+
+    parts.append("</feed>")
+    atom_file.write_text("\n".join(parts), encoding="utf-8")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Export all GitHub issues to mdBook src markdown files"
@@ -111,6 +174,11 @@ def main() -> None:
         default=str(DEFAULT_SUMMARY_FILE),
         help="Path of SUMMARY.md",
     )
+    parser.add_argument(
+        "--atom-file",
+        default=str(DEFAULT_ATOM_FILE),
+        help="Path of atom.xml",
+    )
     args = parser.parse_args()
 
     issues = fetch_all_issues(args.repo, args.token or None)
@@ -127,11 +195,16 @@ def main() -> None:
 
     output_dir = Path(args.output_dir)
     summary_file = Path(args.summary_file)
+    atom_file = Path(args.atom_file)
 
     write_issue_files(filtered, output_dir)
     write_summary(filtered, summary_file)
+    write_atom(filtered, atom_file)
 
-    print(f"Synced {len(filtered)} issues into {output_dir} and {summary_file}")
+    print(
+        f"Synced {len(filtered)} issues into {output_dir}, "
+        f"{summary_file}, and {atom_file}"
+    )
 
 
 if __name__ == "__main__":

--- a/export_issues.py
+++ b/export_issues.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Sync GitHub issues into mdBook markdown files.
 
-- Reads all issues from a repo (paginated)
-- Skips pull requests
+- Reads all issues from a repo via `gh issue list` (excludes PRs automatically)
 - Skips issues labeled TODO (configurable)
 - Writes files to src/blogs/qiwihui-blog-<issue_number>.md
 - Rebuilds src/SUMMARY.md sorted by issue number (desc)
@@ -11,59 +10,41 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, Iterable, List
-
-import requests
 
 DEFAULT_REPO = "qiwihui/blog"
 DEFAULT_OUTPUT_DIR = Path("src/blogs")
 DEFAULT_SUMMARY_FILE = Path("src/SUMMARY.md")
 
 
-def github_headers(token: str | None) -> Dict[str, str]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
 def fetch_all_issues(repo: str, token: str | None) -> List[Dict]:
-    """Fetch all issues from GitHub (includes PRs from /issues endpoint)."""
-    all_issues: List[Dict] = []
-    page = 1
-    per_page = 100
+    """Fetch all issues (not PRs) via gh CLI, which handles auth and pagination."""
+    env = os.environ.copy()
+    if token:
+        env["GH_TOKEN"] = token
 
-    while True:
-        url = f"https://api.github.com/repos/{repo}/issues"
-        resp = requests.get(
-            url,
-            params={
-                "state": "all",
-                "per_page": per_page,
-                "page": page,
-                "sort": "created",
-                "direction": "asc",
-            },
-            headers=github_headers(token),
-            timeout=30,
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", "all",
+        "--json", "number,title,body,labels,state,url",
+        "--limit", "10000",
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue list failed (exit {result.returncode}):\n{result.stderr.strip()}"
         )
-        resp.raise_for_status()
-        chunk = resp.json()
-        if not chunk:
-            break
 
-        all_issues.extend(chunk)
-        if len(chunk) < per_page:
-            break
-        page += 1
-
-    return all_issues
+    issues = json.loads(result.stdout)
+    print(f"Fetched {len(issues)} issues from {repo}")
+    return issues
 
 
 def labels_of(issue: Dict) -> List[str]:
@@ -74,7 +55,7 @@ def issue_markdown(issue: Dict) -> str:
     title = issue.get("title", "")
     body = issue.get("body") or ""
     number = issue.get("number")
-    issue_url = issue.get("html_url", "")
+    issue_url = issue.get("url") or issue.get("html_url", "")
     state = issue.get("state", "unknown")
 
     return (
@@ -94,7 +75,7 @@ def write_issue_files(issues: Iterable[Dict], output_dir: Path) -> None:
         file_path.write_text(issue_markdown(issue), encoding="utf-8")
 
 
-def write_summary(issues: Iterable[Dict], summary_file: Path, output_dir: Path) -> None:
+def write_summary(issues: Iterable[Dict], summary_file: Path) -> None:
     sorted_issues = sorted(issues, key=lambda x: x["number"], reverse=True)
 
     lines = ["# Summary", "", "[About Me](./README.md)"]
@@ -108,27 +89,38 @@ def write_summary(issues: Iterable[Dict], summary_file: Path, output_dir: Path) 
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Export all GitHub issues to mdBook src markdown files")
-    parser.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY", DEFAULT_REPO), help="owner/repo")
-    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN", ""), help="GitHub token")
+    parser = argparse.ArgumentParser(
+        description="Export all GitHub issues to mdBook src markdown files"
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.getenv("GITHUB_REPOSITORY", DEFAULT_REPO),
+        help="owner/repo",
+    )
+    parser.add_argument(
+        "--token", default=os.getenv("GITHUB_TOKEN", ""), help="GitHub token"
+    )
     parser.add_argument("--skip-label", default="TODO", help="Label name to skip")
-    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Output directory for markdown files")
-    parser.add_argument("--summary-file", default=str(DEFAULT_SUMMARY_FILE), help="Path of SUMMARY.md")
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Output directory for markdown files",
+    )
+    parser.add_argument(
+        "--summary-file",
+        default=str(DEFAULT_SUMMARY_FILE),
+        help="Path of SUMMARY.md",
+    )
     args = parser.parse_args()
 
     issues = fetch_all_issues(args.repo, args.token or None)
 
-    filtered = [
-        i
-        for i in issues
-        if "pull_request" not in i and args.skip_label not in labels_of(i)
-    ]
+    filtered = [i for i in issues if args.skip_label not in labels_of(i)]
 
     if not filtered:
         print(
-            f"ERROR: fetched {len(issues)} items from API but 0 passed the filter "
-            f"(skip_label={args.skip_label!r}). Refusing to overwrite {args.summary_file} "
-            "with empty content — check token permissions and repo name.",
+            f"ERROR: fetched {len(issues)} issues but 0 passed the filter "
+            f"(skip_label={args.skip_label!r}). Refusing to overwrite {args.summary_file}.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -137,7 +129,7 @@ def main() -> None:
     summary_file = Path(args.summary_file)
 
     write_issue_files(filtered, output_dir)
-    write_summary(filtered, summary_file, output_dir)
+    write_summary(filtered, summary_file)
 
     print(f"Synced {len(filtered)} issues into {output_dir} and {summary_file}")
 


### PR DESCRIPTION
## 变更概览

修复 `sync-issues-to-src` 工作流的所有已知问题，并新增 atom.xml 自动生成。

---

## 1. 修复：改用 `gh issue list` 替换 `requests` 分页

**根本原因**：原来用 Python `requests` 调用 GitHub REST API 存在两种失败场景：
- Token 有 `issues: none` 时，page 1 静默返回 `[]` → 脚本得到空列表 → SUMMARY.md 被清空
- 无 token 时，page 2 返回 403

**修复**：改用 `gh issue list`（ubuntu-latest 预装），它自动读取 `GITHUB_TOKEN`，内置分页，只返回 issues（不含 PR），失败时报清晰错误。

## 2. 修复：空列表安全检查

若 issue 列表为空，脚本以非零退出码中止，不覆盖 SUMMARY.md，`Create Pull Request` 步骤也会被跳过。

## 3. 修复：添加 `issues: read` 权限 + `concurrency` 并发控制

- `issues: read`：防止 GITHUB_TOKEN 无法读取 issue
- `concurrency: sync-issues-to-src`：防止多次 issue 事件同时触发，产生重复 PR

## 4. 新增：atom.xml 自动生成

每次 sync 同步重新生成 `src/atom.xml`：
- 包含最近 20 条更新的 issue
- 有效的 Atom feed：`<id>` 使用完整 URI，entry `<id>` 使用 GitHub issue URL
- `<published>` = issue 创建时间，`<updated>` = issue 最后更新时间
- 正文从 markdown 转换为 HTML（`markdown` 库）

## 文件变更

| 文件 | 变更 |
|------|------|
| `export_issues.py` | 改用 gh CLI；新增 `write_atom()`；新增 `--atom-file` 参数 |
| `.github/workflows/sync-issues-to-src.yml` | 添加 `issues: read`、`concurrency`；移除 `requests`；添加 `pip install markdown` |
| `.gitignore` | 添加 `__pycache__/` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPCPwUYcaZnCfrPU7PNKHm)_